### PR TITLE
Add specification-driven UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - '**'
+      - main
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - '**'
   pull_request:
     branches:
-      - main
+      - '**'
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run test suite
+        run: yarn test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "parcel src/index.html --dist-dir public",
     "build": "parcel build src/index.html --dist-dir public",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -14,7 +15,12 @@
   "devDependencies": {
     "@types/react": "^18.2.24",
     "@types/react-dom": "^18.2.9",
+    "@testing-library/jest-dom": "^6.4.5",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "jsdom": "^24.0.0",
     "parcel": "^2.12.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/__tests__/ui.spec.tsx
+++ b/src/__tests__/ui.spec.tsx
@@ -33,7 +33,7 @@ describe('Algorithm visualizer UI specification', () => {
   it('renders the size control slider with the specified defaults and range', () => {
     renderWithInit();
 
-    const sizeSlider = screen.getByLabelText(/本数/i) as HTMLInputElement;
+    const sizeSlider = screen.getByRole('slider', { name: /本数/ }) as HTMLInputElement;
     expect(sizeSlider).toHaveAttribute('type', 'range');
     expect(sizeSlider).toHaveAttribute('min', '5');
     expect(sizeSlider).toHaveAttribute('max', '50');
@@ -54,7 +54,7 @@ describe('Algorithm visualizer UI specification', () => {
   it('renders the speed control with the specified range and two-decimal display', async () => {
     renderWithInit();
 
-    const speedSlider = screen.getByLabelText(/アニメ速度/i) as HTMLInputElement;
+    const speedSlider = screen.getByRole('slider', { name: /アニメ速度/ }) as HTMLInputElement;
     expect(speedSlider).toHaveAttribute('type', 'range');
     expect(speedSlider).toHaveAttribute('min', '0.2');
     expect(speedSlider).toHaveAttribute('max', '10');
@@ -104,8 +104,13 @@ describe('Algorithm visualizer UI specification', () => {
     expect(bubblePanel.open).toBe(true);
     expect(quickPanel.open).toBe(true);
 
-    expect(within(bubblePanel).getByText(/ステップ:\s*0/)).toBeInTheDocument();
-    expect(within(quickPanel).getByText(/ステップ:\s*0/)).toBeInTheDocument();
+    const bubbleMeta = bubblePanel.querySelector('.summary-meta');
+    expect(bubbleMeta).not.toBeNull();
+    expect(bubbleMeta).toHaveTextContent(/^ステップ:\s*0$/);
+
+    const quickMeta = quickPanel.querySelector('.summary-meta');
+    expect(quickMeta).not.toBeNull();
+    expect(quickMeta).toHaveTextContent(/^ステップ:\s*0$/);
 
     const bubbleLegend = bubblePanel.querySelector('.legend');
     expect(bubbleLegend).not.toBeNull();
@@ -131,7 +136,7 @@ describe('Algorithm visualizer UI specification', () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: '本数を1増やす' }));
 
-    const sizeSlider = screen.getByLabelText(/本数/i) as HTMLInputElement;
+    const sizeSlider = screen.getByRole('slider', { name: /本数/ }) as HTMLInputElement;
     await waitFor(() => {
       expect(sizeSlider.value).toBe('21');
     });
@@ -151,7 +156,7 @@ describe('Algorithm visualizer UI specification', () => {
   it('rebuilds both panels when the size slider is moved directly', () => {
     renderWithInit();
 
-    const sizeSlider = screen.getByLabelText(/本数/i) as HTMLInputElement;
+    const sizeSlider = screen.getByRole('slider', { name: /本数/ }) as HTMLInputElement;
     fireEvent.input(sizeSlider, { target: { value: '18' } });
 
     expect(sizeSlider.value).toBe('18');
@@ -165,7 +170,7 @@ describe('Algorithm visualizer UI specification', () => {
   it('updates the speed label to two decimal places when the slider value changes', () => {
     renderWithInit();
 
-    const speedSlider = screen.getByLabelText(/アニメ速度/i) as HTMLInputElement;
+    const speedSlider = screen.getByRole('slider', { name: /アニメ速度/ }) as HTMLInputElement;
     fireEvent.input(speedSlider, { target: { value: '2.5' } });
 
     expect(speedSlider.value).toBe('2.5');
@@ -176,7 +181,7 @@ describe('Algorithm visualizer UI specification', () => {
   it('shuffles with the current bar count and keeps both panels synchronized', async () => {
     renderWithInit();
 
-    const sizeSlider = screen.getByLabelText(/本数/i) as HTMLInputElement;
+    const sizeSlider = screen.getByRole('slider', { name: /本数/ }) as HTMLInputElement;
     fireEvent.input(sizeSlider, { target: { value: '12' } });
 
     const randomSpy = vi.spyOn(Math, 'random');

--- a/src/__tests__/ui.spec.tsx
+++ b/src/__tests__/ui.spec.tsx
@@ -109,12 +109,16 @@ describe('Algorithm visualizer UI specification', () => {
 
     const bubbleLegend = bubblePanel.querySelector('.legend');
     expect(bubbleLegend).not.toBeNull();
-    expect(within(bubbleLegend as HTMLElement).getByText(/入れ替え/比較（赤）/)).toBeInTheDocument();
+    expect(
+      within(bubbleLegend as HTMLElement).getByText('入れ替え/比較（赤）'),
+    ).toBeInTheDocument();
     expect(within(bubbleLegend as HTMLElement).getByText(/ソート完了/)).toBeInTheDocument();
 
     const quickLegend = quickPanel.querySelector('.legend');
     expect(quickLegend).not.toBeNull();
-    expect(within(quickLegend as HTMLElement).getByText(/入れ替え/比較（赤）/)).toBeInTheDocument();
+    expect(
+      within(quickLegend as HTMLElement).getByText('入れ替え/比較（赤）'),
+    ).toBeInTheDocument();
     expect(within(quickLegend as HTMLElement).getByText(/ピボット/)).toBeInTheDocument();
     expect(within(quickLegend as HTMLElement).getByText(/境界/)).toBeInTheDocument();
     expect(within(quickLegend as HTMLElement).getByText(/ピボット高/)).toBeInTheDocument();

--- a/src/__tests__/ui.spec.tsx
+++ b/src/__tests__/ui.spec.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import App from '../App';
+import { init } from '../visualizer';
+
+const renderWithInit = () => {
+  const utils = render(<App />);
+  act(() => {
+    init();
+  });
+  return utils;
+};
+
+describe('Algorithm visualizer UI specification', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the size control slider with the specified defaults and range', () => {
+    renderWithInit();
+
+    const sizeSlider = screen.getByLabelText(/本数/i) as HTMLInputElement;
+    expect(sizeSlider).toHaveAttribute('type', 'range');
+    expect(sizeSlider).toHaveAttribute('min', '5');
+    expect(sizeSlider).toHaveAttribute('max', '50');
+    expect(sizeSlider).toHaveAttribute('step', '1');
+    expect(sizeSlider.value).toBe('20');
+
+    const sizeDisplay = document.getElementById('sizeVal');
+    expect(sizeDisplay).toHaveTextContent('20');
+
+    expect(
+      screen.getByRole('button', { name: '本数を1減らす' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: '本数を1増やす' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the speed control with the specified range and two-decimal display', async () => {
+    renderWithInit();
+
+    const speedSlider = screen.getByLabelText(/アニメ速度/i) as HTMLInputElement;
+    expect(speedSlider).toHaveAttribute('type', 'range');
+    expect(speedSlider).toHaveAttribute('min', '0.2');
+    expect(speedSlider).toHaveAttribute('max', '10');
+    expect(speedSlider).toHaveAttribute('step', '0.05');
+    expect(speedSlider.value).toBe('1');
+
+    const speedDisplay = document.getElementById('speedVal');
+    expect(speedDisplay).toHaveTextContent('1.00x');
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: '速度を一段階速く' }));
+    expect(speedSlider.value).toBe('1.05');
+    expect(speedDisplay).toHaveTextContent('1.05x');
+
+    await user.click(screen.getByRole('button', { name: '速度を一段階遅く' }));
+    expect(speedSlider.value).toBe('1.00');
+    expect(speedDisplay).toHaveTextContent('1.00x');
+  });
+
+  it('initializes both algorithm panels with matching bar arrangements and labels', () => {
+    renderWithInit();
+
+    const bubbleBars = document.querySelectorAll<HTMLElement>('#bars-bubble .bar');
+    const quickBars = document.querySelectorAll<HTMLElement>('#bars-quick .bar');
+
+    expect(bubbleBars).toHaveLength(20);
+    expect(quickBars).toHaveLength(20);
+
+    const bubbleHeights = Array.from(bubbleBars, (bar) => bar.style.height);
+    const quickHeights = Array.from(quickBars, (bar) => bar.style.height);
+    expect(bubbleHeights).toEqual(quickHeights);
+
+    bubbleBars.forEach((bar) => {
+      expect(bar.getAttribute('data-label')).toMatch(/^\d+$/);
+    });
+    quickBars.forEach((bar) => {
+      expect(bar.getAttribute('data-label')).toMatch(/^\d+$/);
+    });
+  });
+
+  it('keeps both algorithm panels open by default and shows the required legends and step counters', () => {
+    renderWithInit();
+
+    const bubblePanel = document.getElementById('board-bubble') as HTMLDetailsElement;
+    const quickPanel = document.getElementById('board-quick') as HTMLDetailsElement;
+
+    expect(bubblePanel.open).toBe(true);
+    expect(quickPanel.open).toBe(true);
+
+    expect(within(bubblePanel).getByText(/ステップ:\s*0/)).toBeInTheDocument();
+    expect(within(quickPanel).getByText(/ステップ:\s*0/)).toBeInTheDocument();
+
+    const bubbleLegend = bubblePanel.querySelector('.legend');
+    expect(bubbleLegend).not.toBeNull();
+    expect(within(bubbleLegend as HTMLElement).getByText(/入れ替え/比較（赤）/)).toBeInTheDocument();
+    expect(within(bubbleLegend as HTMLElement).getByText(/ソート完了/)).toBeInTheDocument();
+
+    const quickLegend = quickPanel.querySelector('.legend');
+    expect(quickLegend).not.toBeNull();
+    expect(within(quickLegend as HTMLElement).getByText(/入れ替え/比較（赤）/)).toBeInTheDocument();
+    expect(within(quickLegend as HTMLElement).getByText(/ピボット/)).toBeInTheDocument();
+    expect(within(quickLegend as HTMLElement).getByText(/境界/)).toBeInTheDocument();
+    expect(within(quickLegend as HTMLElement).getByText(/ピボット高/)).toBeInTheDocument();
+    expect(within(quickLegend as HTMLElement).getByText(/ソート完了/)).toBeInTheDocument();
+  });
+
+  it('increments the bar count immediately when using the size stepper controls', async () => {
+    renderWithInit();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: '本数を1増やす' }));
+
+    const sizeSlider = screen.getByLabelText(/本数/i) as HTMLInputElement;
+    await waitFor(() => {
+      expect(sizeSlider.value).toBe('21');
+    });
+    const sizeDisplay = document.getElementById('sizeVal');
+    expect(sizeDisplay).toHaveTextContent('21');
+
+    const bubbleBars = document.querySelectorAll('#bars-bubble .bar');
+    const quickBars = document.querySelectorAll('#bars-quick .bar');
+    expect(bubbleBars).toHaveLength(21);
+    expect(quickBars).toHaveLength(21);
+
+    const bubbleHeights = Array.from(bubbleBars, (bar) => (bar as HTMLElement).style.height);
+    const quickHeights = Array.from(quickBars, (bar) => (bar as HTMLElement).style.height);
+    expect(bubbleHeights).toEqual(quickHeights);
+  });
+
+  it('rebuilds both panels when the size slider is moved directly', () => {
+    renderWithInit();
+
+    const sizeSlider = screen.getByLabelText(/本数/i) as HTMLInputElement;
+    fireEvent.input(sizeSlider, { target: { value: '18' } });
+
+    expect(sizeSlider.value).toBe('18');
+    const sizeDisplay = document.getElementById('sizeVal');
+    expect(sizeDisplay).toHaveTextContent('18');
+
+    expect(document.querySelectorAll('#bars-bubble .bar')).toHaveLength(18);
+    expect(document.querySelectorAll('#bars-quick .bar')).toHaveLength(18);
+  });
+
+  it('updates the speed label to two decimal places when the slider value changes', () => {
+    renderWithInit();
+
+    const speedSlider = screen.getByLabelText(/アニメ速度/i) as HTMLInputElement;
+    fireEvent.input(speedSlider, { target: { value: '2.5' } });
+
+    expect(speedSlider.value).toBe('2.5');
+    const speedDisplay = document.getElementById('speedVal');
+    expect(speedDisplay).toHaveTextContent('2.50x');
+  });
+
+  it('shuffles with the current bar count and keeps both panels synchronized', async () => {
+    renderWithInit();
+
+    const sizeSlider = screen.getByLabelText(/本数/i) as HTMLInputElement;
+    fireEvent.input(sizeSlider, { target: { value: '12' } });
+
+    const randomSpy = vi.spyOn(Math, 'random');
+    const before = randomSpy.mock.calls.length;
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'シャッフル' }));
+
+    const after = randomSpy.mock.calls.length;
+    expect(after).toBeGreaterThan(before);
+
+    const expectedCount = Number(sizeSlider.value);
+    const bubbleBars = document.querySelectorAll('#bars-bubble .bar');
+    const quickBars = document.querySelectorAll('#bars-quick .bar');
+    expect(bubbleBars).toHaveLength(expectedCount);
+    expect(quickBars).toHaveLength(expectedCount);
+
+    const bubbleHeights = Array.from(bubbleBars, (bar) => (bar as HTMLElement).style.height);
+    const quickHeights = Array.from(quickBars, (bar) => (bar as HTMLElement).style.height);
+    expect(bubbleHeights).toEqual(quickHeights);
+  });
+
+  it('hides quick-sort overlay elements until a processing range exists', () => {
+    renderWithInit();
+
+    const boundary = document.getElementById('boundary-line') as HTMLElement | null;
+    const subrange = document.getElementById('subrange-box') as HTMLElement | null;
+    const pivotLine = document.getElementById('pivot-hline') as HTMLElement | null;
+    const zoneLeft = document.getElementById('zone-left') as HTMLElement | null;
+    const zoneRight = document.getElementById('zone-right') as HTMLElement | null;
+
+    expect(boundary?.style.display).toBe('none');
+    expect(subrange?.style.display).toBe('none');
+    expect(pivotLine?.style.display).toBe('none');
+    expect(zoneLeft?.style.display).toBe('none');
+    expect(zoneRight?.style.display).toBe('none');
+  });
+
+  it('sets initial playback controls according to the specification', () => {
+    renderWithInit();
+
+    expect(screen.getByRole('button', { name: /再生/ })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /一時停止/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'シャッフル' })).toBeEnabled();
+  });
+});

--- a/src/__tests__/ui.spec.tsx
+++ b/src/__tests__/ui.spec.tsx
@@ -124,7 +124,9 @@ describe('Algorithm visualizer UI specification', () => {
     expect(
       within(quickLegend as HTMLElement).getByText('入れ替え/比較（赤）'),
     ).toBeInTheDocument();
-    expect(within(quickLegend as HTMLElement).getByText(/ピボット/)).toBeInTheDocument();
+    expect(
+      within(quickLegend as HTMLElement).getByText('ピボット', { exact: true })
+    ).toBeInTheDocument();
     expect(within(quickLegend as HTMLElement).getByText(/境界/)).toBeInTheDocument();
     expect(within(quickLegend as HTMLElement).getByText(/ピボット高/)).toBeInTheDocument();
     expect(within(quickLegend as HTMLElement).getByText(/ソート完了/)).toBeInTheDocument();

--- a/src/__tests__/visualizer.spec.ts
+++ b/src/__tests__/visualizer.spec.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  buildBubbleSteps,
+  buildQuickSteps,
+  genArray,
+  type Step,
+} from '../visualizer';
+type StepWithBoundary = Extract<Step, { t: 'boundary' }>;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function applySwaps(initial: number[], steps: Step[]): number[] {
+  const arr = initial.slice();
+  for (const step of steps) {
+    if (step.t === 'swap') {
+      const { i, j } = step;
+      if (i >= 0 && j >= 0) {
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+    }
+  }
+  return arr;
+}
+
+describe('visualizer logic specification', () => {
+  it('produces bubble sort steps that compare adjacent bars and sort the sequence', () => {
+    const original = [5, 3, 4, 1, 2];
+    const steps = buildBubbleSteps(original);
+    const sorted = applySwaps(original, steps);
+
+    expect(sorted).toEqual([1, 2, 3, 4, 5]);
+
+    const comparisons = steps.filter((step) => step.t === 'compare');
+    const n = original.length;
+    expect(comparisons).toHaveLength((n * (n - 1)) / 2);
+
+    comparisons.forEach((step) => {
+      if (step.t === 'compare') {
+        expect(step.j - step.i).toBe(1);
+      }
+    });
+
+    steps.forEach((step, index) => {
+      if (step.t === 'swap') {
+        expect(index).toBeGreaterThan(0);
+        const prev = steps[index - 1];
+        expect(prev.t).toBe('compare');
+        if (prev.t === 'compare') {
+          expect(prev.i).toBe(step.i);
+          expect(prev.j).toBe(step.j);
+        }
+      }
+    });
+  });
+
+  it('builds quick sort steps that respect the rightmost pivot and produce candidate markers', () => {
+    const original = [5, 1, 4, 2, 3];
+    const steps = buildQuickSteps(original);
+    const sorted = applySwaps(original, steps);
+
+    expect(sorted).toEqual([1, 2, 3, 4, 5]);
+
+    let activeRange: { lo: number; hi: number } | null = null;
+    let currentPivot: number | null = null;
+    let pendingPivotSwap: Extract<Step, { t: 'swap' }> | null = null;
+
+    steps.forEach((step, index) => {
+      switch (step.t) {
+        case 'range': {
+          if (step.lo != null && step.hi != null) {
+            activeRange = { lo: step.lo, hi: step.hi };
+            const next = steps[index + 1] as Step | undefined;
+            expect(next).toBeDefined();
+            expect(next?.t).toBe('pivot');
+            if (next?.t === 'pivot') {
+              expect(next.i).toBe(step.hi);
+            }
+          } else {
+            activeRange = null;
+          }
+          break;
+        }
+        case 'pivot': {
+          if (pendingPivotSwap) {
+            expect(step.i === pendingPivotSwap.i || step.i === pendingPivotSwap.j).toBe(true);
+            pendingPivotSwap = null;
+          }
+          currentPivot = step.i;
+          break;
+        }
+        case 'markL': {
+          expect(activeRange).not.toBeNull();
+          expect(step.i).toBeGreaterThanOrEqual(activeRange!.lo);
+          expect(step.i).toBeLessThanOrEqual(activeRange!.hi);
+          const prev = steps[index - 1];
+          expect(prev.t).toBe('compare');
+          if (prev.t === 'compare') {
+            expect(prev.i).toBe(step.i);
+            expect(prev.j).toBe(currentPivot);
+          }
+          const next = steps[index + 1];
+          expect(next?.t).toBe('boundary');
+          if (next?.t === 'boundary') {
+            expect(next.show).toBe(false);
+            expect(next.lo ?? activeRange!.lo).toBeLessThanOrEqual(activeRange!.hi);
+          }
+          break;
+        }
+        case 'markR': {
+          expect(activeRange).not.toBeNull();
+          expect(step.i).toBeGreaterThanOrEqual(activeRange!.lo);
+          expect(step.i).toBeLessThanOrEqual(activeRange!.hi);
+          const prev = steps[index - 1];
+          expect(prev.t).toBe('compare');
+          if (prev.t === 'compare') {
+            expect(prev.i).toBe(step.i);
+            expect(prev.j).toBe(currentPivot);
+          }
+          break;
+        }
+        case 'swap': {
+          if (activeRange) {
+            expect(step.i).toBeGreaterThanOrEqual(activeRange.lo);
+            expect(step.i).toBeLessThanOrEqual(activeRange.hi);
+            expect(step.j).toBeGreaterThanOrEqual(activeRange.lo);
+            expect(step.j).toBeLessThanOrEqual(activeRange.hi);
+            if (step.j === activeRange.hi) {
+              pendingPivotSwap = step;
+            } else {
+              const window = steps.slice(index + 1, index + 4);
+              const boundary = window.find((s) => s.t === 'boundary') as StepWithBoundary | undefined;
+              expect(boundary).toBeDefined();
+              expect(boundary?.show).toBe(false);
+            }
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    });
+
+    const hasCandidateMarks = steps.some((step) => step.t === 'markL') && steps.some((step) => step.t === 'markR');
+    expect(hasCandidateMarks).toBe(true);
+  });
+
+  it('generates permutations covering the slider specification bounds', () => {
+    const random = vi.spyOn(Math, 'random').mockImplementation(() => 0.5);
+    const five = genArray(5);
+    const fifty = genArray(50);
+    random.mockRestore();
+
+    expect(five).toHaveLength(5);
+    expect(new Set(five)).toHaveSize(5);
+    expect(Math.min(...five)).toBe(1);
+    expect(Math.max(...five)).toBe(5);
+
+    expect(fifty).toHaveLength(50);
+    expect(new Set(fifty)).toHaveSize(50);
+    expect(Math.min(...fifty)).toBe(1);
+    expect(Math.max(...fifty)).toBe(50);
+  });
+});

--- a/src/__tests__/visualizer.spec.ts
+++ b/src/__tests__/visualizer.spec.ts
@@ -153,12 +153,12 @@ describe('visualizer logic specification', () => {
     random.mockRestore();
 
     expect(five).toHaveLength(5);
-    expect(new Set(five)).toHaveSize(5);
+    expect(new Set(five).size).toBe(5);
     expect(Math.min(...five)).toBe(1);
     expect(Math.max(...five)).toBe(5);
 
     expect(fifty).toHaveLength(50);
-    expect(new Set(fifty)).toHaveSize(50);
+    expect(new Set(fifty).size).toBe(50);
     expect(Math.min(...fifty)).toBe(1);
     expect(Math.max(...fifty)).toBe(50);
   });

--- a/src/test/setupTests.ts
+++ b/src/test/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/test/setupTests.ts',
+    restoreMocks: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add a Vitest configuration with jsdom and setup to use Testing Library matchers
- cover toolbar controls, panels, and shuffle behavior with specification-focused UI tests
- expose a setup file to register jest-dom assertions

## Testing
- `yarn test` *(fails locally: vitest binary unavailable until dependencies can be installed in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68c95c91d21883298274e29eb1bb82dd