### PR TITLE
Add custom lint and format tooling with CI checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,50 @@
+name: Lint and Format
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Setup reviewdog
+        uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
+      - name: Lint
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_ENV: production
+        run: |
+          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB origin/${{ github.base_ref }}...HEAD)
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No files to lint."
+            exit 0
+          fi
+          yarn lint:ci -- $CHANGED_FILES | reviewdog -efm="%f:%l:%c: [%t] %m" -name=custom-lint -reporter=github-pr-review -filter-mode=diff -fail-on-error
+      - name: Format check
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB origin/${{ github.base_ref }}...HEAD)
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No files to format."
+            exit 0
+          fi
+          yarn format:check:ci -- $CHANGED_FILES | reviewdog -efm="%f:%l:%c: [%t] %m" -name=custom-format -reporter=github-pr-review -filter-mode=diff -fail-on-error

--- a/package.json
+++ b/package.json
@@ -6,18 +6,23 @@
     "dev": "parcel src/index.html --dist-dir public",
     "build": "parcel build src/index.html --dist-dir public",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "lint": "node ./scripts/lint.mjs",
+    "lint:ci": "node ./scripts/lint.mjs --format unix",
+    "format": "node ./scripts/format.mjs --write",
+    "format:check": "node ./scripts/format.mjs --check",
+    "format:check:ci": "node ./scripts/format.mjs --check --format unix"
   },
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/react": "^18.2.24",
-    "@types/react-dom": "^18.2.9",
     "@testing-library/jest-dom": "^6.4.5",
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.2.24",
+    "@types/react-dom": "^18.2.9",
     "jsdom": "^24.0.0",
     "parcel": "^2.12.0",
     "typescript": "^5.4.5",

--- a/scripts/format.mjs
+++ b/scripts/format.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { execSync } from 'node:child_process';
+import ts from 'typescript';
+const SUPPORTED_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.json', '.yml', '.yaml', '.md']);
+const DEFAULT_TARGETS = ['src', 'package.json', 'tsconfig.json', 'vitest.config.ts', '.github'];
+function parseArgs(argv) {
+    const args = [...argv];
+    const options = { mode: 'check', format: 'stylish', targets: [], formatAll: false };
+    while (args.length > 0) {
+        const arg = args.shift();
+        if (arg === '--write') {
+            options.mode = 'write';
+        }
+        else if (arg === '--check') {
+            options.mode = 'check';
+        }
+        else if (arg === '--format' || arg === '-f') {
+            options.format = args.shift() ?? options.format;
+        }
+        else if (arg.startsWith('--format=')) {
+            options.format = arg.split('=')[1] ?? options.format;
+        }
+        else if (arg === '--all') {
+            options.formatAll = true;
+        }
+        else if (arg === '--help' || arg === '-h') {
+            printHelp();
+            process.exit(0);
+        }
+        else {
+            options.targets.push(arg);
+        }
+    }
+    return options;
+}
+function printHelp() {
+    console.log(`Usage: node scripts/format.mjs [options] [paths...]\n\n` +
+        `Options:\n` +
+        `  --write            Apply formatting changes\n` +
+        `  --check            Check formatting without writing (default)\n` +
+        `  --format, -f       Output format (stylish | unix). Default: stylish\n` +
+        `  --all              Include all default targets\n` +
+        `  --help, -h         Show this message\n` +
+        `\nWithout explicit paths, only files changed from the current HEAD are processed.\n`);
+}
+const IGNORED_DIRECTORIES = new Set(['node_modules', '.git', '.yarn', 'dist', 'public', '.parcel-cache']);
+function getChangedFiles() {
+    try {
+        const changed = new Set();
+        const diffOutput = execSync('git diff --name-only --diff-filter=ACMRTUXB HEAD', {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        diffOutput.split('\n').map((line) => line.trim()).filter(Boolean).forEach((line) => changed.add(line));
+        const untrackedOutput = execSync('git ls-files --others --exclude-standard', {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        untrackedOutput.split('\n').map((line) => line.trim()).filter(Boolean).forEach((line) => changed.add(line));
+        return Array.from(changed);
+    }
+    catch (error) {
+        return [];
+    }
+}
+function collectFiles(targets) {
+    const result = [];
+    const seen = new Set();
+    for (const target of targets) {
+        const absolute = path.resolve(process.cwd(), target);
+        if (!fs.existsSync(absolute)) {
+            continue;
+        }
+        traverse(absolute, result, seen);
+    }
+    return result;
+}
+function traverse(currentPath, collector, seen) {
+    const stat = fs.statSync(currentPath);
+    if (stat.isDirectory()) {
+        const base = path.basename(currentPath);
+        if (IGNORED_DIRECTORIES.has(base)) {
+            return;
+        }
+        const entries = fs.readdirSync(currentPath);
+        for (const entry of entries) {
+            traverse(path.join(currentPath, entry), collector, seen);
+        }
+    }
+    else if (stat.isFile()) {
+        const ext = path.extname(currentPath);
+        if (!SUPPORTED_EXTENSIONS.has(ext)) {
+            return;
+        }
+        const normalized = path.normalize(currentPath);
+        if (!seen.has(normalized)) {
+            collector.push(normalized);
+            seen.add(normalized);
+        }
+    }
+}
+function getScriptKind(extension) {
+    switch (extension) {
+        case '.ts':
+            return ts.ScriptKind.TS;
+        case '.tsx':
+            return ts.ScriptKind.TSX;
+        case '.jsx':
+            return ts.ScriptKind.JSX;
+        case '.js':
+        case '.mjs':
+            return ts.ScriptKind.JS;
+        default:
+            return ts.ScriptKind.Unknown;
+    }
+}
+function formatText(filePath, text) {
+    const extension = path.extname(filePath);
+    if (extension === '.json') {
+        try {
+            const json = JSON.parse(text);
+            return `${JSON.stringify(json, null, 2)}\n`;
+        }
+        catch (error) {
+            return text;
+        }
+    }
+    if (extension === '.yml' || extension === '.yaml' || extension === '.md') {
+        return text.endsWith('\n') ? text : `${text}\n`;
+    }
+    const scriptKind = getScriptKind(extension);
+    const sourceFile = ts.createSourceFile(filePath, text, ts.ScriptTarget.Latest, true, scriptKind);
+    const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+    const printed = printer.printFile(sourceFile);
+    return printed.endsWith('\n') ? printed : `${printed}\n`;
+}
+function formatStylish(issues) {
+    if (issues.length === 0) {
+        console.log('✓ Formatting looks good');
+        return;
+    }
+    for (const issue of issues) {
+        console.log(`${issue.filePath}: needs formatting`);
+    }
+}
+function formatUnix(issues) {
+    for (const issue of issues) {
+        console.log(`${issue.filePath}:1:1: [E] format: ${issue.message}`);
+    }
+}
+function main() {
+    const options = parseArgs(process.argv.slice(2));
+    let targets = options.targets;
+    if (targets.length === 0) {
+        if (options.formatAll) {
+            targets = DEFAULT_TARGETS;
+        }
+        else {
+            const changed = getChangedFiles();
+            if (changed.length > 0) {
+                targets = changed;
+            }
+        }
+    }
+    const files = collectFiles(targets);
+    if (files.length === 0) {
+        if (options.mode === 'check') {
+            console.log('No matching files found. Use --all to format the entire project.');
+        }
+        return;
+    }
+    const issues = [];
+    for (const filePath of files) {
+        const original = fs.readFileSync(filePath, 'utf8');
+        const formatted = formatText(filePath, original);
+        if (options.mode === 'write') {
+            if (formatted !== original) {
+                fs.writeFileSync(filePath, formatted, 'utf8');
+            }
+        }
+        else {
+            if (formatted !== original) {
+                issues.push({
+                    filePath: path.relative(process.cwd(), filePath),
+                    message: 'File is not formatted. Run `yarn format` to update.',
+                });
+            }
+        }
+    }
+    if (options.mode === 'check') {
+        if (options.format === 'unix') {
+            formatUnix(issues);
+        }
+        else {
+            formatStylish(issues);
+        }
+        process.exit(issues.length === 0 ? 0 : 1);
+    }
+}
+main();

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { execSync } from 'node:child_process';
+import ts from 'typescript';
+const SUPPORTED_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs']);
+const DEFAULT_TARGETS = ['src'];
+function parseArgs(argv) {
+    const args = [...argv];
+    const options = { format: 'stylish', targets: [], lintAll: false };
+    while (args.length > 0) {
+        const arg = args.shift();
+        if (arg === '--format' || arg === '-f') {
+            options.format = args.shift() ?? options.format;
+        }
+        else if (arg.startsWith('--format=')) {
+            options.format = arg.split('=')[1] ?? options.format;
+        }
+        else if (arg === '--all') {
+            options.lintAll = true;
+        }
+        else if (arg === '--help' || arg === '-h') {
+            printHelp();
+            process.exit(0);
+        }
+        else {
+            options.targets.push(arg);
+        }
+    }
+    return options;
+}
+function printHelp() {
+    console.log(`Usage: node scripts/lint.mjs [options] [paths...]\n\n` +
+        `Options:\n` +
+        `  --format, -f <format>  Output format (stylish | unix). Default: stylish\n` +
+        `  --all                  Lint all default targets\n` +
+        `  --help, -h             Show this message\n` +
+        `\nWithout explicit paths, only files changed from the current HEAD are linted.\n`);
+}
+function collectFiles(targets) {
+    const result = [];
+    const seen = new Set();
+    for (const target of targets) {
+        const absolute = path.resolve(process.cwd(), target);
+        if (!fs.existsSync(absolute)) {
+            continue;
+        }
+        traverse(absolute, result, seen);
+    }
+    return result;
+}
+const IGNORED_DIRECTORIES = new Set(['node_modules', '.git', '.yarn', 'dist', 'public', '.parcel-cache']);
+function getChangedFiles() {
+    try {
+        const changed = new Set();
+        const diffOutput = execSync('git diff --name-only --diff-filter=ACMRTUXB HEAD', {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        diffOutput.split('\n').map((line) => line.trim()).filter(Boolean).forEach((line) => changed.add(line));
+        const untrackedOutput = execSync('git ls-files --others --exclude-standard', {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        untrackedOutput.split('\n').map((line) => line.trim()).filter(Boolean).forEach((line) => changed.add(line));
+        return Array.from(changed);
+    }
+    catch (error) {
+        return [];
+    }
+}
+function traverse(currentPath, collector, seen) {
+    const stat = fs.statSync(currentPath);
+    if (stat.isDirectory()) {
+        const base = path.basename(currentPath);
+        if (IGNORED_DIRECTORIES.has(base)) {
+            return;
+        }
+        const entries = fs.readdirSync(currentPath);
+        for (const entry of entries) {
+            traverse(path.join(currentPath, entry), collector, seen);
+        }
+    }
+    else if (stat.isFile()) {
+        const ext = path.extname(currentPath);
+        if (!SUPPORTED_EXTENSIONS.has(ext)) {
+            return;
+        }
+        const normalized = path.normalize(currentPath);
+        if (!seen.has(normalized)) {
+            collector.push(normalized);
+            seen.add(normalized);
+        }
+    }
+}
+function buildProgram(files) {
+    return ts.createProgram(files, {
+        allowJs: true,
+        checkJs: true,
+        jsx: ts.JsxEmit.ReactJSX,
+        target: ts.ScriptTarget.ES2020,
+        module: ts.ModuleKind.ESNext,
+        skipLibCheck: true,
+        allowNonTsExtensions: true,
+    });
+}
+function createIssue(filePath, sourceFile, node, ruleId, severity, message) {
+    const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart());
+    return {
+        filePath: path.relative(process.cwd(), filePath),
+        line: line + 1,
+        column: character + 1,
+        ruleId,
+        severity,
+        message,
+    };
+}
+function lint(program, files) {
+    const issues = [];
+    const checker = program.getTypeChecker();
+    const isProduction = process.env.NODE_ENV === 'production';
+    for (const filePath of files) {
+        const sourceFile = program.getSourceFile(filePath);
+        if (!sourceFile) {
+            continue;
+        }
+        const letDeclarations = new Map();
+        function markLet(symbol, info) {
+            if (!symbol) {
+                return;
+            }
+            const key = symbol.escapedName.toString();
+            if (!letDeclarations.has(key)) {
+                letDeclarations.set(key, { ...info, reassigned: false });
+            }
+        }
+        function noteReassignment(symbol) {
+            if (!symbol) {
+                return;
+            }
+            const key = symbol.escapedName.toString();
+            const existing = letDeclarations.get(key);
+            if (existing) {
+                existing.reassigned = true;
+            }
+        }
+        function inspectLoop(body) {
+            const statements = ts.isBlock(body) ? [...body.statements] : [body];
+            if (statements.length === 0) {
+                return;
+            }
+            const first = statements[0];
+            if (ts.isBlock(body) && statements.length === 1 && (ts.isBreakStatement(first) || ts.isReturnStatement(first) || ts.isThrowStatement(first))) {
+                issues.push(createIssue(filePath, sourceFile, first, 'no-unreachable-loop', 'error', 'This loop exits on its first iteration.'));
+            }
+            else if (!ts.isBlock(body) && (ts.isBreakStatement(first) || ts.isReturnStatement(first) || ts.isThrowStatement(first))) {
+                issues.push(createIssue(filePath, sourceFile, first, 'no-unreachable-loop', 'error', 'This loop exits on its first iteration.'));
+            }
+        }
+        function visit(node) {
+            if (ts.isDebuggerStatement(node)) {
+                issues.push(createIssue(filePath, sourceFile, node, 'no-debugger', 'warn', 'Unexpected debugger statement.'));
+            }
+            if (ts.isCallExpression(node)) {
+                const expression = node.expression;
+                if (ts.isPropertyAccessExpression(expression)) {
+                    if (ts.isIdentifier(expression.expression) && expression.expression.text === 'console') {
+                        const severity = isProduction ? 'error' : 'warn';
+                        issues.push(createIssue(filePath, sourceFile, expression.name, 'no-console', severity, `Unexpected console.${expression.name.text} call.`));
+                    }
+                }
+                if (ts.isParenthesizedExpression(expression) && ts.isPropertyAccessExpression(expression.expression) && expression.expression.questionDotToken && !node.questionDotToken) {
+                    issues.push(createIssue(filePath, sourceFile, node, 'no-unsafe-optional-chaining', 'error', 'Optional chaining call should be explicitly chained.'));
+                }
+            }
+            if (ts.isEmptyStatement(node)) {
+                const parent = node.parent;
+                if (!ts.isForStatement(parent) && !ts.isWhileStatement(parent) && !ts.isDoStatement(parent)) {
+                    issues.push(createIssue(filePath, sourceFile, node, 'no-extra-semi', 'warn', 'Unnecessary semicolon.'));
+                }
+            }
+            if (ts.isElementAccessExpression(node)) {
+                const argument = node.argumentExpression;
+                if (argument && ts.isStringLiteral(argument)) {
+                    if (/^[A-Za-z_$][0-9A-Za-z_$]*$/.test(argument.text)) {
+                        issues.push(createIssue(filePath, sourceFile, node.argumentExpression, 'dot-notation', 'warn', 'Use dot notation instead of bracket notation.'));
+                    }
+                }
+            }
+            if (ts.isBinaryExpression(node)) {
+                if (node.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken || node.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsToken) {
+                    issues.push(createIssue(filePath, sourceFile, node.operatorToken, 'eqeqeq', 'error', 'Use === and !== instead of == and !=.'));
+                }
+                if (isAssignmentOperator(node.operatorToken.kind)) {
+                    const target = node.left;
+                    if (ts.isIdentifier(target)) {
+                        noteReassignment(checker.getSymbolAtLocation(target));
+                    }
+                }
+            }
+            if (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) {
+                if (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken) {
+                    const operand = node.operand;
+                    if (ts.isIdentifier(operand)) {
+                        noteReassignment(checker.getSymbolAtLocation(operand));
+                    }
+                }
+            }
+            if (ts.isVariableDeclarationList(node)) {
+                const flags = ts.getCombinedNodeFlags(node);
+                if ((flags & ts.NodeFlags.Var) === ts.NodeFlags.Var) {
+                    issues.push(createIssue(filePath, sourceFile, node, 'no-var', 'error', 'Unexpected var, use let or const instead.'));
+                }
+                if ((flags & ts.NodeFlags.Let) === ts.NodeFlags.Let) {
+                    for (const declaration of node.declarations) {
+                        if (ts.isIdentifier(declaration.name)) {
+                            const parent = node.parent;
+                            const inForInOf = ts.isForInStatement(parent) || ts.isForOfStatement(parent);
+                            const symbol = checker.getSymbolAtLocation(declaration.name);
+                            markLet(symbol, { node: declaration, sourceFile, inForInOf });
+                        }
+                    }
+                }
+            }
+            if (ts.isIfStatement(node)) {
+                if (!ts.isBlock(node.thenStatement)) {
+                    issues.push(createIssue(filePath, sourceFile, node.thenStatement, 'curly', 'error', 'Expected { } around if body.'));
+                }
+                if (node.elseStatement && !ts.isBlock(node.elseStatement) && !ts.isIfStatement(node.elseStatement)) {
+                    issues.push(createIssue(filePath, sourceFile, node.elseStatement, 'curly', 'error', 'Expected { } around else body.'));
+                }
+            }
+            if (ts.isForStatement(node) || ts.isWhileStatement(node) || ts.isDoStatement(node) || ts.isForInStatement(node) || ts.isForOfStatement(node)) {
+                if (!ts.isBlock(node.statement)) {
+                    issues.push(createIssue(filePath, sourceFile, node.statement, 'curly', 'error', 'Expected { } around loop body.'));
+                }
+                inspectLoop(node.statement);
+            }
+            ts.forEachChild(node, visit);
+        }
+        visit(sourceFile);
+        for (const info of letDeclarations.values()) {
+            if (info.inForInOf) {
+                continue;
+            }
+            if (!info.reassigned) {
+                issues.push(createIssue(filePath, sourceFile, info.node.name, 'prefer-const', 'error', 'Use const instead of let.'));
+            }
+        }
+    }
+    return issues;
+}
+function isAssignmentOperator(kind) {
+    switch (kind) {
+        case ts.SyntaxKind.EqualsToken:
+        case ts.SyntaxKind.PlusEqualsToken:
+        case ts.SyntaxKind.MinusEqualsToken:
+        case ts.SyntaxKind.AsteriskEqualsToken:
+        case ts.SyntaxKind.AsteriskAsteriskEqualsToken:
+        case ts.SyntaxKind.SlashEqualsToken:
+        case ts.SyntaxKind.PercentEqualsToken:
+        case ts.SyntaxKind.AmpersandEqualsToken:
+        case ts.SyntaxKind.BarEqualsToken:
+        case ts.SyntaxKind.CaretEqualsToken:
+        case ts.SyntaxKind.LessThanLessThanEqualsToken:
+        case ts.SyntaxKind.GreaterThanGreaterThanEqualsToken:
+        case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken:
+            return true;
+        default:
+            return false;
+    }
+}
+function formatStylish(issues) {
+    if (issues.length === 0) {
+        console.log('✓ No lint issues found');
+        return;
+    }
+    const grouped = new Map();
+    for (const issue of issues) {
+        if (!grouped.has(issue.filePath)) {
+            grouped.set(issue.filePath, []);
+        }
+        grouped.get(issue.filePath).push(issue);
+    }
+    for (const [filePath, fileIssues] of grouped) {
+        console.log(filePath);
+        for (const issue of fileIssues.sort((a, b) => a.line - b.line || a.column - b.column)) {
+            const sev = issue.severity === 'error' ? 'error' : 'warn ';
+            console.log(`  ${issue.line}:${issue.column}  ${sev}  ${issue.ruleId}  ${issue.message}`);
+        }
+    }
+}
+function formatUnix(issues) {
+    for (const issue of issues) {
+        const marker = issue.severity === 'error' ? 'E' : 'W';
+        console.log(`${issue.filePath}:${issue.line}:${issue.column}: [${marker}] ${issue.ruleId}: ${issue.message}`);
+    }
+}
+function main() {
+    const options = parseArgs(process.argv.slice(2));
+    let targets = options.targets;
+    if (targets.length === 0) {
+        if (options.lintAll) {
+            targets = DEFAULT_TARGETS;
+        }
+        else {
+            const changed = getChangedFiles();
+            if (changed.length > 0) {
+                targets = changed;
+            }
+        }
+    }
+    const files = collectFiles(targets);
+    if (files.length === 0) {
+        console.log('No matching files found. Use --all to lint the entire project.');
+        process.exit(0);
+    }
+    const program = buildProgram(files);
+    const issues = lint(program, files).sort((a, b) => {
+        if (a.filePath !== b.filePath) {
+            return a.filePath.localeCompare(b.filePath);
+        }
+        if (a.line !== b.line) {
+            return a.line - b.line;
+        }
+        return a.column - b.column;
+    });
+    if (options.format === 'unix') {
+        formatUnix(issues);
+    }
+    else {
+        formatStylish(issues);
+    }
+    const hasError = issues.some((issue) => issue.severity === 'error');
+    process.exit(hasError ? 1 : 0);
+}
+main();


### PR DESCRIPTION
## Summary
- add a custom TypeScript-powered lint script that enforces the requested coding rules and defaults to the files changed in the current branch
- add a formatter script that normalizes TypeScript/JavaScript and JSON/YAML/Markdown sources while leaving other files alone
- wire a GitHub Actions workflow that runs the new lint and format checks via yarn and reports issues on the pull request using reviewdog

## Testing
- node scripts/lint.mjs --format unix
- node scripts/format.mjs --check --format unix


------
https://chatgpt.com/codex/tasks/task_e_68ca453533388329b9ae73824d962507